### PR TITLE
Workaround for issue experienced with mktime on Micropython

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -148,11 +148,11 @@ class GPS:
         if data is None or len(data) != 14:
             return  # Unexpected number of params.
         # Parse fix time.
-        time_utc = _parse_float(data[0])
+        time_utc = int(_parse_float(data[0]))
         if time_utc is not None:
             hours = time_utc // 10000
-            mins = int((time_utc // 100) % 100)
-            secs = int(time_utc % 100)
+            mins = (time_utc // 100) % 100
+            secs = time_utc % 100
             # Set or update time to a friendly python time struct.
             if self.timestamp_utc is not None:
                 self.timestamp_utc = time.struct_time((
@@ -184,11 +184,11 @@ class GPS:
         if data is None or len(data) < 11:
             return  # Unexpected number of params.
         # Parse fix time.
-        time_utc = _parse_float(data[0])
+        time_utc = int(_parse_float(data[0]))
         if time_utc is not None:
             hours = time_utc // 10000
-            mins = int((time_utc // 100) % 100)
-            secs = int(time_utc % 100)
+            mins = (time_utc // 100) % 100
+            secs = time_utc % 100
             # Set or update time to a friendly python time struct.
             if self.timestamp_utc is not None:
                 self.timestamp_utc = time.struct_time((

--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -152,7 +152,7 @@ class GPS:
         if time_utc is not None:
             hours = time_utc // 10000
             mins = int((time_utc // 100) % 100)
-            secs = time_utc % 100
+            secs = int(time_utc % 100)
             # Set or update time to a friendly python time struct.
             if self.timestamp_utc is not None:
                 self.timestamp_utc = time.struct_time((
@@ -188,7 +188,7 @@ class GPS:
         if time_utc is not None:
             hours = time_utc // 10000
             mins = int((time_utc // 100) % 100)
-            secs = time_utc % 100
+            secs = int(time_utc % 100)
             # Set or update time to a friendly python time struct.
             if self.timestamp_utc is not None:
                 self.timestamp_utc = time.struct_time((


### PR DESCRIPTION
This change fixes an issue I experienced when using the adafruit_gps module from micropython using a CircuitPython-compatibility wrapper. Where the time value provided is a floating point number, then the secs value is also a float after the remainder operation.

The implementation of struct_time in the compatibility layer fails when the struct_time is used to call micropython's mktime, which operates with a stricter interpretation of https://docs.python.org/3.1/library/time.html 

> The time value as returned by gmtime(), localtime(), and strptime(), and accepted by asctime(), mktime() and strftime(), is a sequence of 9 integers. 

...hence requires the secs argument to be an integer when constructing the timestamp. 

Wrapping the secs calculation in int() resolves the issue. The issue I experienced may be specific to the GPS module which returns the value in this form, and to the library downstream which tries to use it and dies, so feel free to ignore if there are reasons not to merge.


