### PR TITLE
Add check that data[0] is not None before trying to parse it

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -195,7 +195,7 @@ class GPS:
         # Parse the arguments (everything after data type) for NMEA GPRMC
         # minimum location fix sentence.
         data = args.split(',')
-        if data is None or len(data) < 11:
+        if data is None or len(data) < 11 or data[0] is None:
             return  # Unexpected number of params.
         # Parse fix time.
         time_utc = int(_parse_float(data[0]))


### PR DESCRIPTION
Fix for https://github.com/adafruit/Adafruit_CircuitPython_GPS/issues/5

I don't have the hardware to test this with, but based on the library source and gps_simpletest.py, the `update` method should be able to be called at any time (even if the GPS doesn't have a location fix yet). At least one type of device (whatever GPS eighthree was using) can emit NMEA GPRMC data in a way that has all the fields with the data as `None`, so we need to check for that case too so the parser method doesn't try anyway and raise an exception.