### PR TITLE
Add datetime property to use GPS object as time source 

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -133,6 +133,11 @@ class GPS:
         """True if a current fix for location information is available."""
         return self.fix_quality is not None and self.fix_quality >= 1
 
+    @property
+    def datetime(self):
+        """Return struct_time object to feed rtc.set_time_source() function"""
+        return self.timestamp_utc
+
     def _parse_sentence(self):
         # Parse any NMEA sentence that is available.
         # pylint: disable=len-as-condition

--- a/examples/time_source.py
+++ b/examples/time_source.py
@@ -1,0 +1,42 @@
+import busio, board, time, rtc
+import adafruit_gps
+
+uart = busio.UART(board.TX, board.RX, baudrate = 9600, timeout=3000)
+
+gps = adafruit_gps.GPS(uart, debug=False)
+gps.send_command(b'PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0')
+gps.send_command(b'PMTK220,1000')
+
+print("Set GPS as time source")
+rtc.set_time_source(gps)
+
+last_print = time.monotonic()
+while True:
+
+    gps.update()
+    # Every second print out current time from GPS, RTC and time.localtime()
+    current = time.monotonic()
+    if current - last_print >= 1.0:
+        last_print = current
+        print('Fix timestamp: {:02}/{:02}/{} {:02}:{:02}:{:02}'.format(
+            gps.timestamp_utc.tm_mon,   # Grab parts of the time from the
+            gps.timestamp_utc.tm_mday,  # struct_time object that holds
+            gps.timestamp_utc.tm_year,  # the fix time.  Note you might
+            gps.timestamp_utc.tm_hour,  # not get all data like year, day,
+            gps.timestamp_utc.tm_min,   # month!
+            gps.timestamp_utc.tm_sec))
+        print('RTC timestamp: {:02}/{:02}/{} {:02}:{:02}:{:02}'.format(
+            rtc.RTC.datetime.tm_mon,
+            rtc.RTC.datetime.tm_mday,
+            rtc.RTC.datetime.tm_year,
+            rtc.RTC.datetime.tm_hour,
+            rtc.RTC.datetime.tm_min,
+            rtc.RTC.datetime.tm_sec))
+        local_time = time.localtime()
+        print("Local time: {:02}/{:02}/{} {:02}:{:02}:{:02}".format(
+            local_time.tm_mon,
+            local_time.tm_mday,
+            local_time.tm_year,
+            local_time.tm_hour,
+            local_time.tm_min,
+            local_time.tm_sec))


### PR DESCRIPTION
Simply add datetime property to use GPS object as time source for rtc.set_time_source() function ( https://circuitpython.readthedocs.io/en/3.x/shared-bindings/rtc/__init__.html ).

See new example script for usage.