### PR TITLE
Add Adafruit-Blinka to requirements.txt for PyPI compatibility

### DIFF
--- a/examples/time_source.py
+++ b/examples/time_source.py
@@ -4,8 +4,8 @@
 
 import time
 import board
-import rtc
 import busio
+import rtc
 import adafruit_gps
 
 uart = busio.UART(board.TX, board.RX, baudrate=9600, timeout=3000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+Adafruit-Blinka
 pyserial


### PR DESCRIPTION
Fix for repo-level issue listed in https://github.com/adafruit/circuitpython/issues/1246

> For pypi compatibility, missing Adafruit-Blinka in requirements.txt - 18
> ...
> * https://github.com/adafruit/Adafruit_CircuitPython_GPS