### PR TITLE
Update adafruit_gps.py

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -142,6 +142,11 @@ class GPS:
         # Parse any NMEA sentence that is available.
         # pylint: disable=len-as-condition
         # This needs to be refactored when it can be tested.
+
+        # Only continue if we have at least 64 bytes in the input buffer
+        if self._uart.in_waiting < 64:
+            return None
+
         sentence = self._uart.readline()
         if sentence is None or sentence == b'' or len(sentence) < 1:
             return None


### PR DESCRIPTION
I was trying to call update() in the adafruit_gps.py module and it would take quite a while, blocking my program from continuing until `_uart.readline()` returned. 

By adding a check to make sure the number of bytes in the input buffer was at least 64, the module doesn't seem to block while waiting for bytes in the buffer.