### PR TITLE
feat(raw): Adding raw sentence

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -115,6 +115,7 @@ class GPS:
         self.total_mess_num = None
         self.mess_num = None
         self.debug = debug
+        self.sentence = None
 
     def update(self):
         """Check for updated data from the GPS module and process it
@@ -200,6 +201,7 @@ class GPS:
                 actual ^= ord(sentence[i])
             if actual != expected:
                 return None  # Failed to validate checksum.
+            self.sentence = sentence
             # Remove checksum once validated.
             sentence = sentence[:-3]
         # Parse out the type of sentence (first string after $ up to comma)


### PR DESCRIPTION
I am unsure if this is within the scope of contributing to the module. 

I purchased the Adafruit ultimate GPS feather, the Adafruit M4 express board, and finally the OLED board, with the hopes that I can log both the raw NMEA sentence to the SD card, at the same time display the current data with the OLED. 

However, I realized that this module never exposed the raw sentence post parsing. I've added the functionality for the raw NMEA sentence to be fetched.