### PR TITLE
Fix typo s/# Tuen on/# Turn on/ in examples/gps_simpletest.py

### DIFF
--- a/examples/gps_simpletest.py
+++ b/examples/gps_simpletest.py
@@ -36,7 +36,7 @@ gps.send_command(b"PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0")
 # gps.send_command(b'PMTK314,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0')
 # Turn off everything:
 # gps.send_command(b'PMTK314,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0')
-# Tuen on everything (not all of it is parsed!)
+# Turn on everything (not all of it is parsed!)
 # gps.send_command(b'PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0')
 
 # Set update rate to once a second (1hz) which is what you typically want.


### PR DESCRIPTION
Noticed this in https://learn.adafruit.com/adafruit-ultimate-gps/circuitpython-python-uart-usage where gps_simpletest.py is presented for download.

Not sure if this change will affect that page also.