### PR TITLE
Implement GSV and GSA parsing

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -121,15 +121,27 @@ class GPS:
             print(sentence)
         data_type, args = sentence
         data_type = bytes(data_type.upper(), "ascii")
-        # return sentence
-        if data_type in (
-            b"GPGLL",
-            b"GNGLL",
-        ):  # GLL, Geographic Position – Latitude/Longitude
+        (talker, sentence_type) = (data_type[:2], data_type[2:])
+
+        # Check for all currently known talkers
+        # GA - Galileo
+        # GB - BeiDou Systems
+        # GI - NavIC
+        # GL - GLONASS
+        # GP - GPS
+        # GQ - QZSS
+        # GN - GNSS / More than one of the above
+        if talker not in (b'GA', b'GB', b'GI', b'GL', b'GP', b'GQ', b'GN'):
+            if self.debug:
+                print(f"  Unknown talker: {talker}")
+            # We don't know the talker so it's not new data
+            return False
+
+        if sentence_type == b'GLL':    # Geographic position - Latitude/Longitude
             self._parse_gpgll(args)
-        elif data_type in (b"GPRMC", b"GNRMC"):  # RMC, minimum location info
+        elif sentence_type == b'RMC':  # Minimum location info
             self._parse_gprmc(args)
-        elif data_type in (b"GPGGA", b"GNGGA"):  # GGA, 3d location fix
+        elif sentence_type == b'GGA':  # 3D location fix
             self._parse_gpgga(args)
         return True
 

--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -90,8 +90,8 @@ class GPS:
         self.height_geoid = None
         self.speed_knots = None
         self.track_angle_deg = None
-        self._sats = None # Temporary holder for information from GSV messages
-        self.sats = None # Completed information from GSV messages
+        self._sats = None  # Temporary holder for information from GSV messages
+        self.sats = None  # Completed information from GSV messages
         self.isactivedata = None
         self.true_track = None
         self.mag_track = None
@@ -132,19 +132,19 @@ class GPS:
         # GP - GPS
         # GQ - QZSS
         # GN - GNSS / More than one of the above
-        if talker not in (b'GA', b'GB', b'GI', b'GL', b'GP', b'GQ', b'GN'):
+        if talker not in (b"GA", b"GB", b"GI", b"GL", b"GP", b"GQ", b"GN"):
             # It's not a known GNSS source of data
             return True
 
-        if sentence_type == b'GLL':    # Geographic position - Latitude/Longitude
+        if sentence_type == b"GLL":  # Geographic position - Latitude/Longitude
             self._parse_gpgll(args)
-        elif sentence_type == b'RMC':  # Minimum location info
+        elif sentence_type == b"RMC":  # Minimum location info
             self._parse_gprmc(args)
-        elif sentence_type == b'GGA':  # 3D location fix
+        elif sentence_type == b"GGA":  # 3D location fix
             self._parse_gpgga(args)
-        elif sentence_type == b'GSV':  # Satellites in view
+        elif sentence_type == b"GSV":  # Satellites in view
             self._parse_gpgsv(talker, args)
-        elif sentence_type == b'GSA':  # GPS DOP and active satellites
+        elif sentence_type == b"GSA":  # GPS DOP and active satellites
             self._parse_gpgsa(talker, args)
         return True
 
@@ -258,7 +258,7 @@ class GPS:
 
     def _parse_talker(self, data_type):
         # Split the data_type into talker and sentence_type
-        if data_type[0] == b'P': # Proprietary codes
+        if data_type[0] == b"P":  # Proprietary codes
             return (data_type[:1], data_type[1:])
         else:
             return (data_type[:2], data_type[2:])
@@ -425,7 +425,7 @@ class GPS:
         self.height_geoid = _parse_float(data[10])
 
     def _parse_gpgsa(self, talker, args):
-        talker = talker.decode('ascii')
+        talker = talker.decode("ascii")
         data = args.split(",")
         if data is None or (data[0] == ""):
             return  # Unexpected number of params
@@ -449,7 +449,7 @@ class GPS:
     def _parse_gpgsv(self, talker, args):
         # Parse the arguments (everything after data type) for NMEA GPGGA
         # 3D location fix sentence.
-        talker = talker.decode('ascii')
+        talker = talker.decode("ascii")
         data = args.split(",")
         if data is None or (data[0] == ""):
             return  # Unexpected number of params.

--- a/examples/gps_satellitefix.py
+++ b/examples/gps_satellitefix.py
@@ -3,7 +3,6 @@
 
 import time
 import board
-import busio
 
 import adafruit_gps
 
@@ -87,21 +86,20 @@ while True:
         print(f"  PDOP (Position Dilution of Precision): {format_dop(gps.pdop)}")
         print(f"  HDOP (Horizontal Dilution of Precision): {format_dop(gps.hdop)}")
         print(f"  VDOP (Vertical Dilution of Precision): {format_dop(gps.vdop)}")
-        print(f"Satellites used for fix:")
+        print("Satellites used for fix:")
         for s in gps.sat_prns:
             talker = talkers[s[0:2]]
             number = s[2:]
+            print(f"  {talker}-{number} ", end="")
             if gps.sats is None:
-                print(f"  {talker}-{number} - no info")
+                print("- no info")
             else:
                 try:
                     sat = gps.sats[s]
                     if sat is None:
-                        print(f"  {talker}-{number} - no info")
+                        print("- no info")
                     else:
-                        print(
-                            f"  {talker}-{number} Elevation:{sat[1]}* Azimuth:{sat[2]}* SNR:{sat[3]}dB"
-                        )
+                        print(f"Elevation:{sat[1]}* Azimuth:{sat[2]}* SNR:{sat[3]}dB")
                 except KeyError:
-                    print(f"  {talker}-{number} - no info")
+                    print("- no info")
         print()

--- a/examples/gps_satellitefix.py
+++ b/examples/gps_satellitefix.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2021 lesamouraipourpre
+# SPDX-License-Identifier: MIT
+
+import time
+import board
+import busio
+
+import adafruit_gps
+
+# Create a serial connection for the GPS connection using default speed and
+# a slightly higher timeout (GPS modules typically update once a second).
+# These are the defaults you should use for the GPS FeatherWing.
+# For other boards set RX = GPS module TX, and TX = GPS module RX pins.
+# uart = busio.UART(board.TX, board.RX, baudrate=9600, timeout=10)
+
+# for a computer, use the pyserial library for uart access
+# import serial
+# uart = serial.Serial("/dev/ttyUSB0", baudrate=9600, timeout=10)
+
+# If using I2C, we'll create an I2C interface to talk to using default pins
+i2c = board.I2C()
+
+# Create a GPS module instance.
+# gps = adafruit_gps.GPS(uart, debug=False)  # Use UART/pyserial
+gps = adafruit_gps.GPS_GtopI2C(i2c, debug=False)  # Use I2C interface
+
+# Initialize the GPS module by changing what data it sends and at what rate.
+# These are NMEA extensions for PMTK_314_SET_NMEA_OUTPUT and
+# PMTK_220_SET_NMEA_UPDATERATE but you can send anything from here to adjust
+# the GPS module behavior:
+#   https://cdn-shop.adafruit.com/datasheets/PMTK_A11.pdf
+
+# Turn on everything (not all of it is parsed!)
+gps.send_command(b'PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0')
+
+# Set update rate to once a second (1hz) which is what you typically want.
+gps.send_command(b"PMTK220,1000")
+# Or decrease to once every two seconds by doubling the millisecond value.
+# Be sure to also increase your UART timeout above!
+# gps.send_command(b'PMTK220,2000')
+# You can also speed up the rate, but don't go too fast or else you can lose
+# data during parsing.  This would be twice a second (2hz, 500ms delay):
+# gps.send_command(b'PMTK220,500')
+
+def format_dop(dop):
+    # https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)
+    if dop > 20:
+        msg = "Poor"
+    elif dop > 10:
+        msg = "Fair"
+    elif dop > 5:
+        msg = "Moderate"
+    elif dop > 2:
+        msg = "Good"
+    elif dop > 1:
+        msg = "Excellent"
+    else:
+        msg = "Ideal"
+    return f"{dop} - {msg}"
+
+talkers = {
+    'GA': 'Galileo',
+    'GB': 'BeiDou',
+    'GI': 'NavIC',
+    'GL': 'GLONASS',
+    'GP': 'GPS',
+    'GQ': 'QZSS',
+    'GN': 'GNSS'
+    }
+
+# Main loop runs forever printing the location, etc. every second.
+last_print = time.monotonic()
+while True:
+    # Make sure to call gps.update() every loop iteration and at least twice
+    # as fast as data comes from the GPS unit (usually every second).
+    # This returns a bool that's true if it parsed new data (you can ignore it
+    # though if you don't care and instead look at the has_fix property).
+    if not gps.update() or not gps.has_fix:
+        time.sleep(0.1)
+        continue
+
+    if gps.nmea_sentence[3:6] == "GSA":
+        print(f"{gps.latitude:.6f}, {gps.longitude:.6f} {gps.altitude_m}m")
+        print(f"2D Fix: {gps.has_fix}  3D Fix: {gps.has_3d_fix}")
+        print(f"  PDOP (Position Dilution of Precision): {format_dop(gps.pdop)}")
+        print(f"  HDOP (Horizontal Dilution of Precision): {format_dop(gps.hdop)}")
+        print(f"  VDOP (Vertical Dilution of Precision): {format_dop(gps.vdop)}")
+        print(f"Satellites used for fix:")
+        for s in gps.sat_prns:
+            talker = talkers[s[0:2]]
+            number = s[2:]
+            if gps.sats is None:
+                print(f"  {talker}-{number} - no info")
+            else:
+                try:
+                    sat = gps.sats[s]
+                    if sat is None:
+                        print(f"  {talker}-{number} - no info")
+                    else:
+                        print(f"  {talker}-{number} Elevation:{sat[1]}* Azimuth:{sat[2]}* SNR:{sat[3]}dB")
+                except KeyError:
+                   print(f"  {talker}-{number} - no info") 
+        print()

--- a/examples/gps_satellitefix.py
+++ b/examples/gps_satellitefix.py
@@ -31,7 +31,7 @@ gps = adafruit_gps.GPS_GtopI2C(i2c, debug=False)  # Use I2C interface
 #   https://cdn-shop.adafruit.com/datasheets/PMTK_A11.pdf
 
 # Turn on everything (not all of it is parsed!)
-gps.send_command(b'PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0')
+gps.send_command(b"PMTK314,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0")
 
 # Set update rate to once a second (1hz) which is what you typically want.
 gps.send_command(b"PMTK220,1000")
@@ -41,6 +41,7 @@ gps.send_command(b"PMTK220,1000")
 # You can also speed up the rate, but don't go too fast or else you can lose
 # data during parsing.  This would be twice a second (2hz, 500ms delay):
 # gps.send_command(b'PMTK220,500')
+
 
 def format_dop(dop):
     # https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)
@@ -58,15 +59,16 @@ def format_dop(dop):
         msg = "Ideal"
     return f"{dop} - {msg}"
 
+
 talkers = {
-    'GA': 'Galileo',
-    'GB': 'BeiDou',
-    'GI': 'NavIC',
-    'GL': 'GLONASS',
-    'GP': 'GPS',
-    'GQ': 'QZSS',
-    'GN': 'GNSS'
-    }
+    "GA": "Galileo",
+    "GB": "BeiDou",
+    "GI": "NavIC",
+    "GL": "GLONASS",
+    "GP": "GPS",
+    "GQ": "QZSS",
+    "GN": "GNSS",
+}
 
 # Main loop runs forever printing the location, etc. every second.
 last_print = time.monotonic()
@@ -97,7 +99,9 @@ while True:
                     if sat is None:
                         print(f"  {talker}-{number} - no info")
                     else:
-                        print(f"  {talker}-{number} Elevation:{sat[1]}* Azimuth:{sat[2]}* SNR:{sat[3]}dB")
+                        print(
+                            f"  {talker}-{number} Elevation:{sat[1]}* Azimuth:{sat[2]}* SNR:{sat[3]}dB"
+                        )
                 except KeyError:
-                   print(f"  {talker}-{number} - no info") 
+                    print(f"  {talker}-{number} - no info")
         print()


### PR DESCRIPTION
This PR aims to get GSA and GSV message parsing operational.
This will hopefully close #51 and #52.

For the talkers #52:
In the update() method the `data_type` is now split into: `talker` (first two characters) and `sentence_type` (remaining three characters)
The `talker` is the source of the message. For now, I've only listed the GNSS sources, eg. GA (Galileo), GB (BeiDou) etc.
NB: GN as a talker means the information is from more than one source.
The `sentence_type` is the sentence type of the message. Eg. GLL (Geographic Position - Lat/Long), GSV (Satellites in View) etc.
Separating these out makes it easier to add extra `talker`s and `sentence_type`s later if needed.

For GSA and GSV #51:
This has been reworked with the aim of handling messages from multiple sources, for example I receive sentences from GPS and GLONASS. Unlike some `sentence_type`s, I've never received GN (multi-source information) messages for GSA and GSV, they are always from a single satellite network.
The satellite information that is stored in the `self.sats` dictionary has been modified to have a key based on the source of the information, eg. GP17 for GPS satellite 17, GL78 for GLONNASS satellite etc.
The value stored is now a 5-value tuple: (Key/Satellite ID, Elevation, Azimuth, SNR, Timestamp)
The timestamp is the `time.monotonic()` that the information was received. This will be used to delete any entries which are older than 30 seconds.

Hardware tested:
I have the [Adafruit Mini GPS PA1010D - UART and I2C - STEMMA QT](https://www.adafruit.com/product/4415)

Example Code:
There is an example in `examples/gps_satellitefix.py` 

This is listed as draft because it needs more testing, preferably with different GPS chips. I would appreciate if others are able to run this and see what breaks.
Also, any feedback on whether the changes made are appropriate or need further work are greatly appreciated.
