### PR TITLE
Add a check on the length of the datatype

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -248,6 +248,8 @@ class GPS:
         if self.debug:
             print(sentence)
         data_type, args = sentence
+        if len(data_type) < 5:
+            return False
         data_type = bytes(data_type.upper(), "ascii")
         (talker, sentence_type) = _parse_talker(data_type)
 


### PR DESCRIPTION
Add a length check to prevent 'IndexError: bytes index out of range' from occurring within _parse_talker