### PR TITLE
Allow use of existing sentence for updating

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -232,7 +232,7 @@ class GPS:
         self._magnetic_variation = None
         self.debug = debug
 
-    def update(self):
+    def update(self, sentence=None):
         """Check for updated data from the GPS module and process it
         accordingly.  Returns True if new data was processed, and False if
         nothing new was received.
@@ -241,7 +241,7 @@ class GPS:
         # parsing function.
 
         try:
-            sentence = self._parse_sentence()
+            sentence = self._parse_sentence(sentence)
         except UnicodeError:
             return None
         if sentence is None:
@@ -340,16 +340,17 @@ class GPS:
         the underlying UART or this will block forever!"""
         return self._uart.readline()
 
-    def _read_sentence(self):
+    def _read_sentence(self, sentence=None):
         # Parse any NMEA sentence that is available.
         # pylint: disable=len-as-condition
         # This needs to be refactored when it can be tested.
 
         # Only continue if we have at least 11 bytes in the input buffer
-        if self.in_waiting < 11:
+        if self.in_waiting < 11 and sentence is None:
             return None
 
-        sentence = self.readline()
+        if sentence is None:
+            sentence = self.readline()
         if sentence is None or sentence == b"" or len(sentence) < 1:
             return None
         try:
@@ -373,8 +374,8 @@ class GPS:
         # At this point we don't have a valid sentence
         return None
 
-    def _parse_sentence(self):
-        sentence = self._read_sentence()
+    def _parse_sentence(self, sentence=None):
+        sentence = self._read_sentence(sentence)
 
         # sentence is a valid NMEA with a valid checksum
         if sentence is None:


### PR DESCRIPTION
I was wanting to periodically display GPS information and also log it. The problem I was running into is that `readline()` empties the buffer so that when using `update()` in the same loop it does not update.

This allows for an example like:

```python
import busio
import time

from sdcard import SDCard
from adafruit_gps import GPS

SPI = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
CS = board.D10
UART_GPS = busio.UART(board.TX, board.RX, baudrate=9600, timeout=10)

sd = sdcardio.SDCard(SPI, CS)
vfs = storage.VfsFat(sd)
storage.mount(vfs, "/sd")
gps = GPS(UART_GPS)
timer = time.monotonic()

with open("/sd/test.txt", "ab") as f:
    while True:
        sentence = gps.readline()

        if sentence:
            f.write(sentence)

            if timer + 10 < time.monotonic()
                gps.update(sentence)
                print(f"Satellites: {gps.satellites}")
                print(f"Fix: {gps.fix_quality}")

                if gps.latitude and mygps.longitude:
                    print("Latitude: {0:.6f}".format(gps.latitude))
                    print("Longitude: {0:.6f}".format(gps.longitude))

                print("Time: {}".format(gps.timestamp_utc))

                timer = time.monotonic()
```