### PR TITLE
fix bug where `has_fix` remained `True` even though the fix was lost

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -446,6 +446,7 @@ class GPS:
             return False  # Unexpected number of params.
         data = _parse_data({12: _RMC, 13: _RMC_4_1}[len(data)], data)
         if data is None:
+            self.fix_quality = 0
             return False  # Params didn't parse
 
         # UTC time of position and date
@@ -489,6 +490,7 @@ class GPS:
             return False  # Unexpected number of params.
         data = _parse_data(_GGA, data)
         if data is None:
+            self.fix_quality = 0
             return False  # Params didn't parse
 
         # UTC time of position
@@ -541,6 +543,7 @@ class GPS:
         else:
             data = _parse_data(_GSA_4_11, data)
         if data is None:
+            self.fix_quality_3d = 0
             return False  # Params didn't parse
 
         talker = talker.decode("ascii")


### PR DESCRIPTION
I am experiencing the following behavior with this sample code:
```python
import time
import serial

import adafruit_gps

uart = serial.Serial('/dev/ttyS0', baudrate=9600, timeout=10)

gps = adafruit_gps.GPS(uart, debug=False)
gps.send_command(b"PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0")
gps.send_command(b"PMTK220,1000")

while True:
    gps.update()
    print(f'gps.has_fix={gps.has_fix}')
    print(f'gps.has_3d_fix={gps.has_3d_fix}')
    print(f'gps.fix_quality={gps.fix_quality}')
    print(f'gps.fix_quality_3d={gps.fix_quality_3d}')
    print('=' * 79)
    time.sleep(.1)

```
1. start the system inside, no fix, red led blinks quicky, everything as expected
```console
gps.has_fix=False
gps.has_3d_fix=False
gps.fix_quality=0
gps.fix_quality_3d=0
```
2. bring the GPS-unit outside, as expected it gets a fix, red led blinks slowly, property `has_fix` is set correctly
```console
gps.has_fix=True
gps.has_3d_fix=False
gps.fix_quality=1
gps.fix_quality_3d=0
```
3. bring the GPS unit back inside, the red LED starts to blink quickly, however it still returns `has_fix=True` 
```console
gps.has_fix=True
gps.has_3d_fix=False
gps.fix_quality=1
gps.fix_quality_3d=0
```

I had a look at what `_read_sentence` returns, and it seems like the GPS continues to return some data for quite some time e.g `b'$GPGGA,150745.000,1234.1234,N,12345.1234,E,1,06,2.89,33.2,M,47.4,M,,*5A\r\n'` .
after a while it actually stops, to return proper data, but `has_fix` remains `True` even though the red led blinks quickly. The number of satellites goes down to 1 and the RMC sends `V` for Warning, but `has_fix` remains true...
```console
b'$GPRMC,154518.000,V,,,,,0.00,0.00,230921,,,N*4A\r\n'
gps.has_fix=True
gps.has_3d_fix=False
gps.fix_quality=6
gps.fix_quality_3d=0
```
# Solution/Fix
The issue is, that the sentence `b'$GPRMC,154518.000,V,,,,,0.00,0.00,230921,,,N*4A\r\n'` cannot be parsed here and the method returns early and `self.fix_quality` is not set and the property `has_fix` remains at the point of the last successfull parse:
https://github.com/adafruit/Adafruit_CircuitPython_GPS/blob/36554486700593bada0e9de7abcb4d83116b04e3/adafruit_gps.py#L447-L449
so this way the code below is never reached:
https://github.com/adafruit/Adafruit_CircuitPython_GPS/blob/36554486700593bada0e9de7abcb4d83116b04e3/adafruit_gps.py#L456-L460

A different way than the one I chose here would be to add another parsing step to check if at least the `A` or `V` parameter is parsable and set `has_fix` according to this. My though for this solution was, that if there was no parsable data, we also don't have a fix so `has_fix` must be false.

This is also the case for `gga` and `gsa`, however they also send a fix parameter in their data, so we could try to parse them separately to differentiate between a lost fix and some other non parsable data problem. I am not sure if this even makes sense to do...