### PR TITLE
fix bug where byte str comparision was done incorrectly

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -113,7 +113,7 @@ def _read_degrees(data, index, neg):
 
 def _parse_talker(data_type):
     # Split the data_type into talker and sentence_type
-    if data_type[0] == b"P":  # Proprietary codes
+    if data_type[:1] == b"P":  # Proprietary codes
         return (data_type[:1], data_type[1:])
 
     return (data_type[:2], data_type[2:])


### PR DESCRIPTION
while writing the tests in #69 I found a small bug, where the behavior might be unexpected. Indexing a bytestring with `b'abc'[0]` will return an integer (97), which is the decimal representation of the ascii character `a`. Accessing ranges (`b'abc'[:1]`) works as expected.