### PR TITLE
update pre-commit conifiguration to avoid using the local escape hatch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,31 +4,30 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 21.9b0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.12.1
+    rev: v0.13.0
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.0.1
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/pycqa/pylint
-    rev: pylint-2.7.1
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v3.0.0a4
     hooks:
     -   id: pylint
         name: pylint (library code)
-        types: [python]
         exclude: "^(docs/|examples/|setup.py$)"
--   repo: local
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v3.0.0a4
     hooks:
-    -   id: pylint_examples
+    -   id: pylint
         name: pylint (examples code)
         description: Run pylint rules on "examples/*.py" files
-        entry: /usr/bin/env bash -c
-        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,consider-using-f-string $example; done)']
-        language: system
+        args: ['--disable=missing-docstring,invalid-name,consider-using-f-string']
+        files: '^examples/.*\.py$'

--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -653,7 +653,9 @@ class GPS_GtopI2C(GPS):
     def __init__(
         self, i2c_bus, *, address=_GPSI2C_DEFAULT_ADDRESS, debug=False, timeout=5
     ):
-        import adafruit_bus_device.i2c_device as i2c_device  # pylint: disable=import-outside-toplevel
+        from adafruit_bus_device import (  # pylint: disable=import-outside-toplevel
+            i2c_device,
+        )
 
         super().__init__(None, debug)  # init the parent with no UART
         self._i2c = i2c_device.I2CDevice(i2c_bus, address)


### PR DESCRIPTION
using `repo: local` in pre-commit is considered an escape hatch, since it is not really portable and relies on the user to have the tools installed. pre-commit provides all the configuration options to be able to achieve what was previously done in bash, also much faster, since the files are now checked in parallel.

I also run autoupdate and had to fix one pylint import error, where afterwards black did some formatting, where I personally don't agree on, but it's at least consistent 😄 

We might also consider enabling [pre-commit.ci](https://pre-commit.ci/) instead of running it in gha, it's a CI tool build for pre-commit which is really fast, auto fixes formatting issue e.g. if a PR comes in a an black was not used, it applies it and commits the changes for you. the autoupdate is run weekly (can be configured differently) and a PR is created if there are newer version of the linters or code formatters.

Since pre-commit seems to be the default in all adafruit repos this might be an option for the whole organization?