### PR TITLE
Add handling with extra precision in lat/long

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -80,10 +80,15 @@ def _parse_degrees(nmea_data):
     # Where ddd is the degrees, mm.mmmm is the minutes.
     if nmea_data is None or len(nmea_data) < 3:
         return None
-    raw = float(nmea_data)
-    deg = raw // 100
-    minutes = raw % 100
-    return deg + minutes / 60
+    # To avoid losing precision handle degrees and minutes separately
+    # Return the final value as an integer. Further functions can parse
+    # this into a float or separate parts to retain the precision
+    raw = nmea_data.split(".")
+    deg = int(raw[0]) // 100 * 1000000  # the ddd
+    minutes = int(raw[0]) % 100 * 10000  # the mm.
+    minutes += int(raw[1])  # the .mmmm
+    minutes = int(minutes / 60 * 100)
+    return deg + minutes
 
 
 def _parse_int(nmea_data):
@@ -105,10 +110,19 @@ def _parse_str(nmea_data):
 
 
 def _read_degrees(data, index, neg):
-    x = data[index]
+    # This function loses precision with float32
+    x = data[index] / 1000000
     if data[index + 1].lower() == neg:
         x *= -1.0
     return x
+
+
+def _read_int_degress(data, index, neg):
+    deg = data[index] // 1000000
+    minutes = data[index] % 1000000 / 10000
+    if data[index + 1].lower() == neg:
+        deg *= -1
+    return (deg, minutes)
 
 
 def _parse_talker(data_type):
@@ -208,7 +222,11 @@ class GPS:
         # Initialize null starting values for GPS attributes.
         self.timestamp_utc = None
         self.latitude = None
+        self.latitude_degrees = None
+        self.latitude_minutes = None  # Use for full precision minutes
         self.longitude = None
+        self.longitude_degrees = None
+        self.longitude_minutes = None  # Use for full precision minutes
         self.fix_quality = 0
         self.fix_quality_3d = 0
         self.satellites = None
@@ -424,9 +442,11 @@ class GPS:
 
         # Latitude
         self.latitude = _read_degrees(data, 0, "s")
+        self.latitude_degrees, self.latitude_minutes = _read_int_degress(data, 0, "s")
 
         # Longitude
         self.longitude = _read_degrees(data, 2, "w")
+        self.longitude_degrees, self.longitude_minutes = _read_int_degress(data, 2, "w")
 
         # UTC time of position
         self._update_timestamp_utc(data[4])
@@ -462,9 +482,11 @@ class GPS:
 
         # Latitude
         self.latitude = _read_degrees(data, 2, "s")
+        self.latitude_degrees, self.latitude_minutes = _read_int_degress(data, 2, "s")
 
         # Longitude
         self.longitude = _read_degrees(data, 4, "w")
+        self.longitude_degrees, self.longitude_minutes = _read_int_degress(data, 4, "w")
 
         # Speed over ground, knots
         self.speed_knots = data[6]
@@ -498,9 +520,11 @@ class GPS:
 
         # Latitude
         self.latitude = _read_degrees(data, 1, "s")
+        self.latitude_degrees, self.latitude_minutes = _read_int_degress(data, 1, "s")
 
         # Longitude
         self.longitude = _read_degrees(data, 3, "w")
+        self.longitude_degrees, self.longitude_minutes = _read_int_degress(data, 3, "w")
 
         # GPS quality indicator
         # 0 - fix not available,

--- a/examples/gps_simpletest.py
+++ b/examples/gps_simpletest.py
@@ -82,6 +82,16 @@ while True:
         )
         print("Latitude: {0:.6f} degrees".format(gps.latitude))
         print("Longitude: {0:.6f} degrees".format(gps.longitude))
+        print(
+            "Precise Latitude: {:2.}{:2.4f} degrees".format(
+                gps.latitude_degrees, gps.latitude_minutes
+            )
+        )
+        print(
+            "Precise Longitude: {:2.}{:2.4f} degrees".format(
+                gps.longitude_degrees, gps.longitude_minutes
+            )
+        )
         print("Fix quality: {}".format(gps.fix_quality))
         # Some attributes beyond latitude, longitude and timestamp are optional
         # and might not be present.  Check if they're None before trying to use!

--- a/tests/adafruit_gps_test.py
+++ b/tests/adafruit_gps_test.py
@@ -21,9 +21,9 @@ from adafruit_gps import GPS
 @pytest.mark.parametrize(
     ("val", "exp"),
     (
-        pytest.param("0023.456", 0.390933, id="leading zero"),
-        pytest.param("6413.9369", 64.23228, id="regular value"),
-        pytest.param("2747.416122087989", 27.79027, id="long value"),
+        pytest.param("0023.456", 390933, id="leading zero"),
+        pytest.param("6413.9369", 64232281, id="regular value"),
+        pytest.param("2747.416122087989", 27790268, id="long value"),
     ),
 )
 def test_parse_degrees(val, exp):


### PR DESCRIPTION
Addresses issue #63 by adding two new latitude and two new longitude attributes for degrees and minutes. When combined as one value the current CP float limit cannot handle the full precision of latitude or longitude.

The `_parse_degrees` function was modified to give more precision to the existing latitude and longitude values (some was lost in the calculation not in the final storage) but that value is still imprecise.