### PR TITLE
use values for satellite dict access instead of items

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -699,7 +699,7 @@ class GPS:
                     # been seen for 30 seconds
                     timestamp = time.monotonic()
                     old = []
-                    for sat in self.sats.items():
+                    for sat in self.sats.values():
                         if (timestamp - sat[4]) > 30:
                             old.append(i)
                     for i in old:


### PR DESCRIPTION
As @jkittner pointed out, `items()` returns a list of tuples of the form `(key, value)`, so on the following line, an index of `4` will always error. The fix uses `values()` instead, so `sat` refers to a data structure that actually has a 5th element. 

Future CI work will make sure that this will get caught by tests before merging (see discussion in PR#96 in this repo)