### PR TITLE
Fix https://github.com/adafruit/Adafruit_CircuitPython_GPS/issues/105

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -26,6 +26,7 @@ Implementation Notes
   https://github.com/adafruit/circuitpython/releases
 
 """
+
 import time
 from micropython import const
 
@@ -61,7 +62,7 @@ _SENTENCE_PARAMS = (
     # 0 - _GLL
     "dcdcscC",
     # 1 - _RMC
-    "scdcdcffsDCC",
+    "scDCDCFFsDCC",
     # 2 - _GGA
     "sdcdciiffsfsIS",
     # 3 - _GSA
@@ -588,6 +589,7 @@ class GPS:
                 self.fix_quality = 1
         else:
             self.fix_quality = 0
+            return True  # break early since no fix means no following values will be populated
 
         # Latitude
         self.latitude = _read_degrees(parsed_data, 2, "s")

--- a/tests/adafruit_gps_test.py
+++ b/tests/adafruit_gps_test.py
@@ -162,6 +162,18 @@ def test_GPS_update_timestamp_timestamp_utc_was_not_none_new_date_none():
     assert gps.timestamp_utc == exp_struct
 
 
+def test_GPS_update_time_from_RTC_without_fix():
+    r = b"$GPRMC,210648.000,V,,,,,0.71,105.86,050425,,,N*4E\r\n"
+    with mock.patch.object(GPS, "readline", return_value=r):
+        gps = GPS(uart=UartMock())
+        gps.update()
+        exp_time = time.struct_time((2025, 4, 5, 21, 6, 48, 0, 0, -1))
+        assert gps.has_fix is False
+        assert gps.timestamp_utc == exp_time
+        assert gps.datetime == exp_time
+        assert gps.nmea_sentence == "$GPRMC,210648.000,V,,,,,0.71,105.86,050425,,,N*4E"
+
+
 def test_GPS_update_with_unknown_talker():
     r = b"$XYRMC,215032.086,A,1234.5678,N,00123.12345,E,0.45,56.35,021021,,,A*7c\r\n"
     with mock.patch.object(GPS, "readline", return_value=r):


### PR DESCRIPTION
Changes parsing for RMC messages to that time values are still reported even if there is not a GPS fix. This is particularly relevant for GPS cards which have a battery included and maintain an RTC clock onboard, eg: the adafruit Ultimate GPS v3.

Note there is a logical change in _parse_rmc which means lat/lon values won't be returned when there's no fix. Prior version could conceivably have allowed this, but I believe that lat/lon/speed values are never provided without a fix in practice.