### PR TITLE
Fix Issue #124 - invalid syntax for integer with base 10

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -490,11 +490,32 @@ class GPS:
         data_type = sentence[1:delimiter]
         return (data_type, sentence[delimiter + 1 :])
 
+    @staticmethod
+    def _parse_hhmmss(time_utc: Optional[str]) -> Optional[Tuple[int, int, int]]:
+        # Parse an NMEA hhmmss(.sss) field into (hours, mins, secs).
+        # Returns None if the field is absent, short, or non-numeric.
+        if time_utc is None or len(time_utc) < 6 or not time_utc[0:6].isdigit():
+            return None
+        return (int(time_utc[0:2]), int(time_utc[2:4]), int(time_utc[4:6]))
+
+    @staticmethod
+    def _parse_ddmmyy(date: Optional[str]) -> Optional[Tuple[int, int, int]]:
+        # Parse an NMEA ddmmyy field into (day, month, year).
+        # Returns None if the field is absent, short, or non-numeric.
+        if date is None or len(date) < 6 or not date[0:6].isdigit():
+            return None
+        return (int(date[0:2]), int(date[2:4]), 2000 + int(date[4:6]))
+
     def _update_timestamp_utc(self, time_utc: str, date: Optional[str] = None) -> None:
-        hours = int(time_utc[0:2])
-        mins = int(time_utc[2:4])
-        secs = int(time_utc[4:6])
-        if date is None:
+        parsed_time = self._parse_hhmmss(time_utc)
+        if parsed_time is None:
+            # Malformed time field; leave the previous timestamp untouched.
+            return
+        hours, mins, secs = parsed_time
+
+        parsed_date = self._parse_ddmmyy(date)
+        if parsed_date is None:
+            # No usable date field; carry forward the date we already have.
             if self.timestamp_utc is None:
                 day, month, year = 0, 0, 0
             else:
@@ -502,9 +523,7 @@ class GPS:
                 month = self.timestamp_utc.tm_mon
                 year = self.timestamp_utc.tm_year
         else:
-            day = int(date[0:2])
-            month = int(date[2:4])
-            year = 2000 + int(date[4:6])
+            day, month, year = parsed_date
 
         self.timestamp_utc = time.struct_time((year, month, day, hours, mins, secs, 0, 0, -1))
 


### PR DESCRIPTION
Carefully parse date and time fields to fix the missing value at times on GPS strings that would cause an exception in _update_timestamp_utc.  Now skip using a bad field rather than raising an "invalid syntax for integer with base 10" exception.

Fixes Issue #124 filed by @T-Mosher and additionally recently seen by me and added to that issue's notes.

I have been running this new code for 3-4 days on the system where I saw this issue: 

RP2350 Pico 2 W, Waveshare L76X GPS backpack and an Adafruit 7 segment LED HT16K33 backpack attached via I2C 

and have not seen the error recur nor any regressions.

I also tested on a Feather ESP32-S3 Reverse TFT with Adafruit Mini GPS PA1010D via both UART and I2C and all the example programs run as well as a version of my GPS clock code.

I have a separate fix I will submit for Issue #123 relating to degree parsing after this one is merged to keep the changes distinct.  

Claude wrote a great fuzzer script which I will attach to this.  It can test the original and new library versions and show that the new code no longer throws exceptions.  NB. The fuzzer is built to test the combined #124 and #123 fixes so when run against this will only fix the invalid syntax for integer and not the index out of range until the subsequent merge.

[gps string fuzzer tests.zip](https://github.com/user-attachments/files/30433777/gps.string.fuzzer.tests.zip)

Here is the output from the fuzzer script:
```
Mac:fuzzer_tests bob$ python3 test_fuzz.py

=== adafruit_gps : 20000 sentences, 50% corrupted ===
     39x  IndexError at _parse_degrees() line 103: minutes += int(f"{raw[1][:4]:0<4}") / 10000
     13x  ValueError at _update_timestamp_utc() line 507: year = 2000 + int(date[4:6])
     12x  ValueError at _update_timestamp_utc() line 496: secs = int(time_utc[4:6])
     11x  ValueError at _read_deg_mins() line 147: deg = int(int_part[:-2])
      7x  ValueError at _update_timestamp_utc() line 506: month = int(date[2:4])
      6x  ValueError at _read_deg_mins() line 140: int_part, minutes_decimal = data[index].split(".")
      6x  TypeError at _read_degrees() line 128: x = data[index] / 1000000
      4x  ValueError at _update_timestamp_utc() line 495: mins = int(time_utc[2:4])
      3x  ValueError at _update_timestamp_utc() line 505: day = int(date[0:2])
      2x  ValueError at _update_timestamp_utc() line 494: hours = int(time_utc[0:2])

=== adafruit_gps_patched : 20000 sentences, 50% corrupted ===
     39x  IndexError at _parse_degrees() line 103: minutes += int(f"{raw[1][:4]:0<4}") / 10000
     11x  ValueError at _read_deg_mins() line 147: deg = int(int_part[:-2])
      6x  ValueError at _read_deg_mins() line 140: int_part, minutes_decimal = data[index].split(".")
      6x  TypeError at _read_degrees() line 128: x = data[index] / 1000000
```