### PR TITLE
Fix issue #123 - "index out of range"

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -183,7 +183,8 @@ def _parse_talker(data_type: bytes) -> Tuple[bytes, bytes]:
     return (data_type[:2], data_type[2:])
 
 
-def _parse_data(sentence_type: int, data: List[str]) -> Optional[List]:
+def _parse_data(sentence_type: int, data: List[str]) -> Optional[List]:  # noqa: PLR0911
+    # PLR0911: each early return is a distinct, self-documenting rejection reason ...
     """Parse sentence data for the specified sentence type and
     return a list of parameters in the correct format, or return None.
     """
@@ -218,8 +219,14 @@ def _parse_data(sentence_type: int, data: List[str]) -> Optional[List]:
                 else:
                     params.append(dti)
             elif pti == "d":
-                # A number parseable as degrees
-                params.append(_parse_degrees(dti))
+                # A number parseable as degrees.
+                # Required field so unparseable or empty should reject whole sentence.
+                if nothing:
+                    return None
+                parsed_degrees = _parse_degrees(dti)
+                if parsed_degrees is None:
+                    return None
+                params.append(parsed_degrees)
             elif pti == "D":
                 # A number parseable as degrees or Nothing
                 if nothing:

--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -89,6 +89,22 @@ _SENTENCE_PARAMS = (
 # Internal helper parsing functions.
 # These handle input that might be none or null and return none instead of
 # throwing errors.
+def _split_decimal(nmea_data: str) -> Tuple[Optional[str], str]:
+    # Split a numeric NMEA field into its integer and fractional digits.
+    # Returns (None, "") if either part is missing or non-numeric. The
+    # fractional part is optional; some receivers omit it entirely.
+    dot = nmea_data.find(".")
+    if dot == -1:
+        int_part, minutes_decimal = nmea_data, "0"
+    else:
+        int_part, minutes_decimal = nmea_data[:dot], nmea_data[dot + 1 :]
+        if not minutes_decimal:
+            minutes_decimal = "0"
+    if not int_part.isdigit() or not minutes_decimal.isdigit():
+        return None, ""
+    return int_part, minutes_decimal
+
+
 def _parse_degrees(nmea_data: str) -> int:
     # Parse a NMEA lat/long data pair 'dddmm.mmmm' into a pure degrees value.
     # Where ddd is the degrees, mm.mmmm is the minutes.
@@ -97,10 +113,12 @@ def _parse_degrees(nmea_data: str) -> int:
     # To avoid losing precision handle degrees and minutes separately
     # Return the final value as an integer. Further functions can parse
     # this into a float or separate parts to retain the precision
-    raw = nmea_data.split(".")
-    degrees = int(raw[0]) // 100 * 1000000  # the ddd
-    minutes = int(raw[0]) % 100  # the mm.
-    minutes += int(f"{raw[1][:4]:0<4}") / 10000
+    int_part, minutes_decimal = _split_decimal(nmea_data)
+    if int_part is None:
+        return None
+    degrees = int(int_part) // 100 * 1000000  # the ddd
+    minutes = int(int_part) % 100  # the mm.
+    minutes += int(f"{minutes_decimal[:4]:0<4}") / 10000
     minutes = int((minutes * 1000000) / 60)
     return degrees + minutes
 
@@ -125,6 +143,8 @@ def _parse_str(nmea_data: str) -> str:
 
 def _read_degrees(data: List[float], index: int, neg: str) -> float:
     # This function loses precision with float32
+    if data[index] is None or data[index + 1] is None:
+        return None
     x = data[index] / 1000000
     if data[index + 1].lower() == neg:
         x *= -1.0
@@ -136,12 +156,14 @@ def _read_deg_mins(data: List[str], index: int, neg: str) -> Tuple[int, float]:
     # longitudes, which makes parsing tricky:
     # for latitudes: ddmm,mmmm (0 - 7 decimal places, not zero padded)
     # for longitudes: dddmm,mmmm (0 - 7 decimal places, not zero padded)
-    if "." in data[index]:
-        int_part, minutes_decimal = data[index].split(".")
-    else:
-        int_part, minutes_decimal = data[index], 0
+    if data[index] is None or len(data[index]) < 3:
+        return None, None
 
     # we need to parse from right to left, minutes can only have 2 digits
+    int_part, minutes_decimal = _split_decimal(data[index])
+    if int_part is None or len(int_part) < 3:
+        return None, None
+
     minutes_int = int_part[-2:]
     # the rest must be degrees which are either 2 or 3 digits
     deg = int(int_part[:-2])


### PR DESCRIPTION
Fix parsing of decimal fields like degrees.  There are times when some GPS controllers leave off the decimal point when a value is whole number only.  The old code split on the decimal point with an index out of range error.

This should fix Issue #123 by @T-Mosher.

The existing comment in the code said the helper functions should return none on bad or missing data but didn't.  

"Internal helper parsing functions.  These handle input that might be none or null and return none instead of throwing errors."

Now the added and changed helper function do return none rather than throwing an error when for instance a degree field doesn't have a decimal point.

I've been running the dual change #124 fix and this one for 3-4 days on my original Pico 2W clock with Waveshare backpack and also on an Feather ESP32-S3 Reverse TFT with Adafruit Mini GPS PA1010D via both UART and I2C and they have run with no errors (more detail in PR #126)

Here is an updated fuzzer (with this change included in the patched test):
[gps string fuzzer tests updated with 123.zip](https://github.com/user-attachments/files/30438921/gps.string.fuzzer.tests.updated.with.123.zip)

The result of running the 124 and 123 changes against the original
```
Mac:gps string fuzzer tests bob$ python3 test_fuzz.py

=== adafruit_gps : 20000 sentences, 50% corrupted ===
     39x  IndexError at _parse_degrees() line 103: minutes += int(f"{raw[1][:4]:0<4}") / 10000
     13x  ValueError at _update_timestamp_utc() line 507: year = 2000 + int(date[4:6])
     12x  ValueError at _update_timestamp_utc() line 496: secs = int(time_utc[4:6])
     11x  ValueError at _read_deg_mins() line 147: deg = int(int_part[:-2])
      7x  ValueError at _update_timestamp_utc() line 506: month = int(date[2:4])
      6x  ValueError at _read_deg_mins() line 140: int_part, minutes_decimal = data[index].split(".")
      6x  TypeError at _read_degrees() line 128: x = data[index] / 1000000
      4x  ValueError at _update_timestamp_utc() line 495: mins = int(time_utc[2:4])
      3x  ValueError at _update_timestamp_utc() line 505: day = int(date[0:2])
      2x  ValueError at _update_timestamp_utc() line 494: hours = int(time_utc[0:2])

=== adafruit_gps_patched : 20000 sentences, 50% corrupted ===
  no exceptions escaped update()
  ```
