### PR TITLE
Two different satelllite counts were stored in the same variable

### DIFF
--- a/adafruit_gps.py
+++ b/adafruit_gps.py
@@ -315,9 +315,14 @@ class GPS:
             |    3 - 3D fix
         """
         self.satellites = None
-        """The number of satellites in use, 0 - 12"""
+        """The number of satellites in use (GGA), 0 - 12"""
         self.satellites_prev = None
         """The number of satellites in use from the previous data point, 0 - 12"""
+        self.satellites_in_view = None
+        """The number of satellites in view (GSV), 0 - 12"""
+        self.satellites_in_view_prev = None
+        """The number of satellites in view from the previous data point, 0 - 12"""
+
         self.horizontal_dilution = None
         """Horizontal dilution of precision (GGA)"""
         self.altitude_m = None
@@ -678,6 +683,9 @@ class GPS:
         # GPS quality indicator
         self.fix_quality = parsed_data[5]
 
+        # Capture previous value
+        self.satellites_prev = self.satellites
+
         # Number of satellites in use, 0 - 12
         self.satellites = parsed_data[6]
 
@@ -754,8 +762,12 @@ class GPS:
         self.total_mess_num = data[0]
         # Message number
         self.mess_num = data[1]
+
+        # Capture previous value
+        self.satellites_in_view_prev = self.satellites_in_view
+
         # Number of satellites in view
-        self.satellites = data[2]
+        self.satellites_in_view = data[2]
 
         sat_tup = data[3:]
 
@@ -784,7 +796,7 @@ class GPS:
 
         if self.mess_num == self.total_mess_num:
             # Last part of GSV message
-            if len(self._sats) == self.satellites:
+            if len(self._sats) == self.satellites_in_view:
                 # Transfer received satellites to self.sats
                 if self.sats is None:
                     self.sats = {}
@@ -801,8 +813,6 @@ class GPS:
                 for sat in self._sats:
                     self.sats[sat[0]] = sat
             self._sats.clear()
-
-        self.satellites_prev = self.satellites
 
         return True
 

--- a/tests/adafruit_gps_test.py
+++ b/tests/adafruit_gps_test.py
@@ -421,7 +421,7 @@ def test_GPS_update_from_GSV_first_part():
         assert gps.update()
         assert gps.total_mess_num == 2
         assert gps.mess_num == 1
-        assert gps.satellites == 8
+        assert gps.satellites_in_view == 8
         # check two satellites, without timestamp, since it is dynamic
         sats = gps._sats
         assert sats[0][:-1] == ("GP1", 40, 83, 46)
@@ -449,7 +449,7 @@ def test_GPS_update_from_GSV_both_parts_sats_are_removed():
             assert gps.update()
             assert gps.total_mess_num == 2
             assert gps.mess_num == 1
-            assert gps.satellites == 4
+            assert gps.satellites_in_view == 4
             # first time we received satellites, so this must be None
             assert gps.sats is None
         # some time has passed so the first two satellites will be too old, but
@@ -460,7 +460,7 @@ def test_GPS_update_from_GSV_both_parts_sats_are_removed():
             assert gps.update()
             assert gps.total_mess_num == 2
             assert gps.mess_num == 2
-            assert gps.satellites == 4
+            assert gps.satellites_in_view == 4
             # we should now have 4 satellites from the two part request
             assert set(gps.sats.keys()) == {"GP1", "GP2", "GP12", "GP14"}
 
@@ -470,7 +470,7 @@ def test_GPS_update_from_GSV_both_parts_sats_are_removed():
             # a third, one part request
             m.return_value = b"$GPGSV,1,1,02,13,07,344,39,15,22,228,45*7a\r\n"
             assert gps.update()
-            assert gps.satellites == 2
+            assert gps.satellites_in_view == 2
             assert set(gps.sats.keys()) == {"GP12", "GP14", "GP13", "GP15"}
 
 


### PR DESCRIPTION
Fix #129

Two different satellite counts were stored in the same variable.  This was brought to my attention by @T-Mosher a while back while working on a different GPS issue.  Whichever was the last NMEA string parsed GGA or GSV would leave its count in the shared variable stomping on each other.  We discussed this here: https://github.com/adafruit/Adafruit_CircuitPython_GPS/issues/123#issuecomment-5212336275

I left satellites and satellites_prev to be the count for the GGA string (Satellites in Use) which is the one enabled in most/all of Adafruit's examples.

I added a satellites_in_view and satellites_in_view_prev to be the new count of satellites from the GSV (Satellites in View).

Since GGA and/or GSV have to be enabled to have their sentences parsed the only changed behavior is where with the dual behavior satellites would contain a number if either GGA or GSV were enabled now satellites will be none when GSV but not GGA is selected and vice_versa for satellites_in_view.  Which I think breaks few to no implementations.

Both T-Mosher and I have tested it on our Adafruit mini GPS but neither of us own a Ultimate GPS.  However this is a very minimal change.